### PR TITLE
Added upcoming/more_info commands, leverage embeds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4==4.12.2
+discord.py==2.3.2
+python_dateutil==2.8.2
+pytz==2023.3
+Requests==2.31.0


### PR DESCRIPTION
Respectfully request pull request. 

I created two new commands, both of which are similar to your /getctf and /getinfo command

The first is the /upcoming command, which give the next 7 days worth of upcoming CTFs in a list format. 
Here's an example:
![image](https://github.com/aaronw-dev/CTFBot/assets/49510984/c9f836ce-93cb-4ed9-b8f2-3a905f4e7391)

The next is the /more_info command, which gives you more info about a CTF by eventID.
Here's an example:
![image](https://github.com/aaronw-dev/CTFBot/assets/49510984/08e156fb-4d32-4ca4-9714-fe331d267968)

The main difference/purpose of this pull request is to leverage the discord.Embed feature, along with the timestamp formatting. The primary benefit is datetime localization, which was of course my main goal. 

Thank you! 